### PR TITLE
Memory overflow resolved

### DIFF
--- a/server.c
+++ b/server.c
@@ -65,6 +65,9 @@ int main(void)
 		if ((new_fd = accept(sockfd, (struct sockaddr *)&their_addr,&sin_size)) == -1)
 		{
 			//perror("accept");
+			// Connection descriptor should be closed
+			// it could cause memory overflow
+			close(new_fd);
 			continue;
 		}
 		printf("Received request from Client: %s:%d\n",


### PR DESCRIPTION
Server side new connections should be closed if we are not going to communicate with them no more.
By not closing connection, we could get memory overflow.